### PR TITLE
Add room id to chat message

### DIFF
--- a/src/main/java/com/github/daniel_sc/rocketchat/modern_client/response/ChatMessage.java
+++ b/src/main/java/com/github/daniel_sc/rocketchat/modern_client/response/ChatMessage.java
@@ -6,14 +6,16 @@ import java.util.Map;
 public class ChatMessage {
     public String msg;
     public User u;
+    public String rid;
     public String _id;
     public DateWrapper editedAt;
     public User editedBy;
     public Map<String,UserList> reactions = new HashMap<>();
 
-    public ChatMessage(String msg, User u, DateWrapper editedAt, User editedBy, Map<String,UserList> reactions) {
+    public ChatMessage(String msg, User u, String rid, DateWrapper editedAt, User editedBy, Map<String,UserList> reactions) {
         this.msg = msg;
         this.u = u;
+        this.rid = rid;
         this.editedAt = editedAt;
         this.editedBy = editedBy;
         this.reactions = reactions;
@@ -28,7 +30,8 @@ public class ChatMessage {
         return "ChatMessage{" +
                 "msg='" + msg + '\'' +
                 ", u=" + u + '\'' +
-                ", _id=" + _id + 
+                ", rid=" + rid + '\'' +
+                ", _id=" + _id +
                 '}';
     }
 }

--- a/src/test/java/com/github/daniel_sc/rocketchat/modern_client/RocketChatClientIT.java
+++ b/src/test/java/com/github/daniel_sc/rocketchat/modern_client/RocketChatClientIT.java
@@ -139,7 +139,7 @@ public class RocketChatClientIT {
         ChatMessage receivedMsg = msgStream.blockingFirst();
 
         assertNotNull(receivedMsg);
-        assertNotNull(receivedMsg.rid);
+        assertEquals(room.rid, receivedMsg.rid);
         assertEquals(msgText, receivedMsg.msg);
         assertNull(receivedMsg.editedBy);
         assertNull(receivedMsg.editedAt);

--- a/src/test/java/com/github/daniel_sc/rocketchat/modern_client/RocketChatClientIT.java
+++ b/src/test/java/com/github/daniel_sc/rocketchat/modern_client/RocketChatClientIT.java
@@ -139,6 +139,7 @@ public class RocketChatClientIT {
         ChatMessage receivedMsg = msgStream.blockingFirst();
 
         assertNotNull(receivedMsg);
+        assertNotNull(receivedMsg.rid);
         assertEquals(msgText, receivedMsg.msg);
         assertNull(receivedMsg.editedBy);
         assertNull(receivedMsg.editedAt);

--- a/src/test/java/com/github/daniel_sc/rocketchat/modern_client/RocketChatClientIT.java
+++ b/src/test/java/com/github/daniel_sc/rocketchat/modern_client/RocketChatClientIT.java
@@ -133,20 +133,22 @@ public class RocketChatClientIT {
         Disposable streamDispose = msgStream.connect();
 
         String msgText = "TEST modern sdk: stream input";
-        subscription.thenCompose(room -> client.sendMessage(msgText, room.rid))
-                .join();
+        String roomId = subscription.thenCompose(sub -> {
+            client.sendMessage(msgText, sub.rid);
+            return CompletableFuture.completedFuture(sub.rid);
+        }).join();
 
         ChatMessage receivedMsg = msgStream.blockingFirst();
 
         assertNotNull(receivedMsg);
-        assertEquals(room.rid, receivedMsg.rid);
+        assertEquals(roomId, receivedMsg.rid);
         assertEquals(msgText, receivedMsg.msg);
         assertNull(receivedMsg.editedBy);
         assertNull(receivedMsg.editedAt);
         assertFalse(receivedMsg.isModified());
 
         String msgTextModified = "TEST modern sdk: stream input (modified)";
-        subscription.thenCompose(room -> client.updateMessage(msgTextModified, receivedMsg._id))
+        subscription.thenCompose(sub -> client.updateMessage(msgTextModified, receivedMsg._id))
                 .join();
 
         ChatMessage receivedModifiedMsg = msgStream.skip(1).blockingFirst();


### PR DESCRIPTION
Currently there is no way to distinguish between direct message and message sent to public channel